### PR TITLE
Keep trim definition selection in sync

### DIFF
--- a/+UserInterface/+StabilityControl/@StabTree/mousePressedInTree_CB.m
+++ b/+UserInterface/+StabilityControl/@StabTree/mousePressedInTree_CB.m
@@ -198,15 +198,18 @@ icon_dir = fullfile( this_dir,'..','..','Resources' );
                             node.setValue('unselected');
                             node.setIcon(obj.JavaImage_unchecked);
                             jtree.treeDidChange();
+                            if strcmp(node.getName,'Trim Definition')
+                                obj.syncTrimDefinitionGeneralNode(node,false);
+                            end
                             if any(strcmp(node.getName,{'Linear Model Definition','Mass Properties','Requirement','Simulation'}))
                                 count = node.getChildCount;
                                 for i = 0:(count-1)
                                     currNode = node.getChildAt(i);
-                                    currNode.setIcon(obj.JavaImage_unchecked); 
+                                    currNode.setIcon(obj.JavaImage_unchecked);
                                     currNode.setValue('unselected');
                                 end
 
-                            elseif any(strcmp(char(node.getParent.getName),{'Linear Model Definition','Mass Properties','Requirement','Simulation'}))
+                            elseif any(strcmp(char(node.getParent.getName),{'Trim Definition','Linear Model Definition','Mass Properties','Requirement','Simulation'}))
                                 count = node.getParent.getChildCount;
                                 for i = 0:(count-1)
                                     currNode = node.getParent.getChildAt(i);
@@ -228,11 +231,14 @@ icon_dir = fullfile( this_dir,'..','..','Resources' );
                             node.setValue('selected');
                             node.setIcon(obj.JavaImage_checked);
                             jtree.treeDidChange();
+                            if strcmp(node.getName,'Trim Definition')
+                                obj.syncTrimDefinitionGeneralNode(node,true);
+                            end
                             if any(strcmp(node.getName,{'Linear Model Definition','Mass Properties','Requirement','Simulation'}))
                                 count = node.getChildCount;
                                 for i = 0:(count-1)
                                     currNode = node.getChildAt(i);
-                                    currNode.setIcon(obj.JavaImage_checked); 
+                                    currNode.setIcon(obj.JavaImage_checked);
                                     currNode.setValue('selected');
                                 end
                             elseif any(strcmp(node.getParent.getName,{'Trim Definition','Output','Analysis Task'}))
@@ -240,13 +246,13 @@ icon_dir = fullfile( this_dir,'..','..','Resources' );
                                 count = parentNode.getChildCount;
                                 for i = 0:(count-1)
                                     currNode = parentNode.getChildAt(i);
-                                    currNode.setIcon(obj.JavaImage_unchecked); 
+                                    currNode.setIcon(obj.JavaImage_unchecked);
                                     currNode.setValue('unselected');
                                 end
                                 node.setValue('selected');
                                 node.setIcon(obj.JavaImage_checked);
                                 jtree.treeDidChange();
-                            elseif any(strcmp(char(node.getParent.getName),{'Linear Model Definition','Mass Properties','Requirement','Simulation'}))
+                            elseif any(strcmp(char(node.getParent.getName),{'Trim Definition','Linear Model Definition','Mass Properties','Requirement','Simulation'}))
                                 count = node.getParent.getChildCount;
                                 for i = 0:(count-1)
                                     currNode = node.getParent.getChildAt(i);

--- a/+UserInterface/+StabilityControl/@StabTree/nodeSelection_CB.m
+++ b/+UserInterface/+StabilityControl/@StabTree/nodeSelection_CB.m
@@ -9,15 +9,18 @@ function nodeSelection_CB( obj , node )
                 node.setValue('unselected');
                 node.setIcon(obj.JavaImage_unchecked);
                 jtree.treeDidChange();
+                if strcmp(node.getName,'Trim Definition')
+                    obj.syncTrimDefinitionGeneralNode(node,false);
+                end
                 if any(strcmp(node.getName,{'Linear Model Definition','Mass Properties','Requirement'}))
                     count = node.getChildCount;
                     for i = 0:(count-1)
                         currNode = node.getChildAt(i);
-                        currNode.setIcon(obj.JavaImage_unchecked); 
+                        currNode.setIcon(obj.JavaImage_unchecked);
                         currNode.setValue('unselected');
                     end
 
-                elseif any(strcmp(char(node.getParent.getName),{'Linear Model Definition','Mass Properties','Requirement'}))
+                elseif any(strcmp(char(node.getParent.getName),{'Trim Definition','Linear Model Definition','Mass Properties','Requirement'}))
                     count = node.getParent.getChildCount;
                     for i = 0:(count-1)
                         currNode = node.getParent.getChildAt(i);
@@ -37,11 +40,14 @@ function nodeSelection_CB( obj , node )
                 node.setValue('selected');
                 node.setIcon(obj.JavaImage_checked);
                 jtree.treeDidChange();
+                if strcmp(node.getName,'Trim Definition')
+                    obj.syncTrimDefinitionGeneralNode(node,true);
+                end
                 if any(strcmp(node.getName,{'Linear Model Definition','Mass Properties','Requirement'}))
                     count = node.getChildCount;
                     for i = 0:(count-1)
                         currNode = node.getChildAt(i);
-                        currNode.setIcon(obj.JavaImage_checked); 
+                        currNode.setIcon(obj.JavaImage_checked);
                         currNode.setValue('selected');
                     end
                 elseif any(strcmp(node.getParent.getName,{'Trim Definition','Output'}))
@@ -55,7 +61,7 @@ function nodeSelection_CB( obj , node )
                     node.setValue('selected');
                     node.setIcon(obj.JavaImage_checked);
                     jtree.treeDidChange();
-                elseif any(strcmp(char(node.getParent.getName),{'Linear Model Definition','Mass Properties','Requirement'}))
+                elseif any(strcmp(char(node.getParent.getName),{'Trim Definition','Linear Model Definition','Mass Properties','Requirement'}))
                     count = node.getParent.getChildCount;
                     for i = 0:(count-1)
                         currNode = node.getParent.getChildAt(i);


### PR DESCRIPTION
## Summary
- set trim definition group nodes to selected by default when inserting trim objects and add a helper to keep the General child aligned with the parent state
- update mouse click and selection callbacks to sync Trim Definition and General nodes while preserving existing notifications

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68c8a57fee54832fa6a65a617e7e9b0d