### PR TITLE
Ensure mass properties precede custom columns in operating condition reports

### DIFF
--- a/+SimViewer/@Report/Report.m
+++ b/+SimViewer/@Report/Report.m
@@ -275,6 +275,59 @@ classdef Report < handle
             end
 
             if ~isempty(operCond)
+                % Mass properties
+                mpFields = struct('name',{},'type',{},'unit',{},'displayName',{});
+                mpNames = {};
+                massProps = operCond(1).MassProperties;
+                if ~isempty(massProps)
+                    mpParams = massProps.Parameter;
+                    if ~isempty(mpParams)
+                        mpNames = {mpParams.Name};
+                    end
+                end
+                for n = 1:numel(mpNames)
+                    vals = arrayfun(@(oc) oc.MassProperties.get(mpNames{n}), operCond, 'UniformOutput', false);
+                    firstVal = vals{1};
+                    if isnumeric(firstVal)
+                        valsNum = cell2mat(vals);
+                        if any(abs(valsNum - valsNum(1)) > 1e-6)
+                            key = keyFcn('Mass Property',mpNames{n});
+                            unit = '';
+                            if isKey(unitMap,key)
+                                unit = unitMap(key);
+                            end
+                            mpFields(end+1) = struct('name',mpNames{n},'type','Mass Property','unit',unit,'displayName',''); %#ok<AGROW>
+                        end
+                    else
+                        if ~all(strcmp(firstVal,vals))
+                            key = keyFcn('Mass Property',mpNames{n});
+                            unit = '';
+                            if isKey(unitMap,key)
+                                unit = unitMap(key);
+                            end
+                            mpFields(end+1) = struct('name',mpNames{n},'type','Mass Property','unit',unit,'displayName',''); %#ok<AGROW>
+                        end
+                    end
+                end
+
+                % Always include the WeightCode mass property column
+                weightFieldName = 'WeightCode';
+                existingNames = [{selFields.name},{mpFields.name}];
+                if ~any(strcmp(existingNames, weightFieldName))
+                    weightKeyCandidates = {keyFcn('Mass Property','Weight Code'), keyFcn('Mass Property','WeightCode')};
+                    unit = '';
+                    for keyIdx = 1:numel(weightKeyCandidates)
+                        key = weightKeyCandidates{keyIdx};
+                        if isKey(unitMap,key)
+                            unit = unitMap(key);
+                            break;
+                        end
+                    end
+                    mpFields(end+1) = struct('name',weightFieldName,'type','Mass Property','unit',unit,'displayName','Weight Code'); %#ok<AGROW>
+                end
+
+                selFields = [selFields, mpFields];
+
                 ts = operCond(1).TrimSettings;
                 if ~isempty(ts)
                     % Inputs
@@ -322,55 +375,7 @@ classdef Report < handle
                         selFields(end+1) = struct('name',name,'type','State Derivatives','unit',unit,'displayName',''); %#ok<AGROW>
                     end
                 end
-
-                % Mass properties
-                mpNames = {};
-                massProps = operCond(1).MassProperties;
-                if ~isempty(massProps)
-                    mpParams = massProps.Parameter;
-                    if ~isempty(mpParams)
-                        mpNames = {mpParams.Name};
-                    end
-                end
-                for n = 1:numel(mpNames)
-                    vals = arrayfun(@(oc) oc.MassProperties.get(mpNames{n}), operCond, 'UniformOutput', false);
-                    firstVal = vals{1};
-                    if isnumeric(firstVal)
-                        valsNum = cell2mat(vals);
-                        if any(abs(valsNum - valsNum(1)) > 1e-6)
-                            key = keyFcn('Mass Property',mpNames{n});
-                            unit = '';
-                            if isKey(unitMap,key)
-                                unit = unitMap(key);
-                            end
-                            selFields(end+1) = struct('name',mpNames{n},'type','Mass Property','unit',unit,'displayName',''); %#ok<AGROW>
-                        end
-                    else
-                        if ~all(strcmp(firstVal,vals))
-                            key = keyFcn('Mass Property',mpNames{n});
-                            unit = '';
-                            if isKey(unitMap,key)
-                                unit = unitMap(key);
-                            end
-                            selFields(end+1) = struct('name',mpNames{n},'type','Mass Property','unit',unit,'displayName',''); %#ok<AGROW>
-                        end
-                    end
-                end
-
-                % Always include the WeightCode mass property column
-                weightFieldName = 'WeightCode';
-                if ~any(strcmp({selFields.name}, weightFieldName))
-                    weightKeyCandidates = {keyFcn('Mass Property','Weight Code'), keyFcn('Mass Property','WeightCode')};
-                    unit = '';
-                    for keyIdx = 1:numel(weightKeyCandidates)
-                        key = weightKeyCandidates{keyIdx};
-                        if isKey(unitMap,key)
-                            unit = unitMap(key);
-                            break;
-                        end
-                    end
-                    selFields(end+1) = struct('name',weightFieldName,'type','Mass Property','unit',unit,'displayName','Weight Code'); %#ok<AGROW>
-                end
+            end
             end
 
             range = obj.ActX_word.Selection.Range;


### PR DESCRIPTION
## Summary
- update the operating condition report builder to collect mass property fields before any user-defined vectors
- apply the same column ordering in the SimViewer report so Flight Condition and Mass Property groups always lead the table

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68c99a4b9e1c832fbbabf244987d23df