### PR TITLE
Remove operating condition header shading

### DIFF
--- a/+SimViewer/@Report/Report.m
+++ b/+SimViewer/@Report/Report.m
@@ -408,8 +408,6 @@ classdef Report < handle
 
             % Header rows
             categories = unique({selFields.type},'stable');
-            colorMap = containers.Map({'Flight Condition','Inputs','Outputs','States','State Derivatives','Mass Property'},...
-                                      {15,7,9,11,13,14});
             col = nr_cols;
             for catIdx = numel(categories):-1:1
                 cat = categories{catIdx};
@@ -422,9 +420,6 @@ classdef Report < handle
                 newTable1.Cell(1,firstCol).Range.InsertAfter(cat);
                 newTable1.Cell(1,firstCol).Range.Bold = 1;
                 newTable1.Cell(1,firstCol).Range.ParagraphFormat.Alignment = 1;
-                if isKey(colorMap,cat)
-                    newTable1.Cell(1,firstCol).Shading.BackgroundPatternColorIndex = colorMap(cat);
-                end
                 col = firstCol - 1;
             end
             headerCells = newTable1.Rows.Item(1).Cells.Count;

--- a/@Report/Report.m
+++ b/@Report/Report.m
@@ -404,8 +404,6 @@ classdef Report < handle
 
             % Header rows
             categories = unique({selFields.type},'stable');
-            colorMap = containers.Map({'Flight Condition','Inputs','Outputs','States','State Derivatives','Mass Property'},...
-                                      {15,7,9,11,13,14});
             col = nr_cols;
             for catIdx = numel(categories):-1:1
                 cat = categories{catIdx};
@@ -418,9 +416,6 @@ classdef Report < handle
                 newTable1.Cell(1,firstCol).Range.InsertAfter(cat);
                 newTable1.Cell(1,firstCol).Range.Bold = 1;
                 newTable1.Cell(1,firstCol).Range.ParagraphFormat.Alignment = 1;
-                if isKey(colorMap,cat)
-                    newTable1.Cell(1,firstCol).Shading.BackgroundPatternColorIndex = colorMap(cat);
-                end
                 col = firstCol - 1;
             end
             headerCells = newTable1.Rows.Item(1).Cells.Count;


### PR DESCRIPTION
## Summary
- remove the custom shading applied to the first header row of operating condition tables in generated reports so the row uses the default background

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68c99f91affc832f810d2eb3e59bfa76