### PR TITLE
Synchronize Trim Definition parent and General nodes

### DIFF
--- a/+UserInterface/+StabilityControl/@StabTree/StabTree.m
+++ b/+UserInterface/+StabilityControl/@StabTree/StabTree.m
@@ -1947,6 +1947,21 @@ classdef StabTree < UserInterface.tree
             childCount = trimNode.getChildCount();
             stateChanged = false;
 
+            % Ensure the parent node reflects the requested state
+            parentValue = char(trimNode.getValue);
+            parentIsSelected = strcmp(parentValue, 'selected');
+            parentIsUnselected = strcmp(parentValue, 'unselected');
+
+            if isSelected && ~parentIsSelected
+                trimNode.setValue('selected');
+                trimNode.setIcon(obj.JavaImage_checked);
+                stateChanged = true;
+            elseif ~isSelected && ~parentIsUnselected
+                trimNode.setValue('unselected');
+                trimNode.setIcon(obj.JavaImage_unchecked);
+                stateChanged = true;
+            end
+
             for idx = 0:(childCount-1)
                 childNode = trimNode.getChildAt(idx);
                 childName = char(childNode.getName);

--- a/+UserInterface/+StabilityControl/@StabTree/mousePressedInTree_CB.m
+++ b/+UserInterface/+StabilityControl/@StabTree/mousePressedInTree_CB.m
@@ -201,14 +201,15 @@ icon_dir = fullfile( this_dir,'..','..','Resources' );
                             if strcmp(node.getName,'Trim Definition')
                                 obj.syncTrimDefinitionGeneralNode(node,false);
                             end
-                            if any(strcmp(node.getName,{'Linear Model Definition','Mass Properties','Requirement','Simulation'}))
+                            if strcmp(node.getName,'General') && strcmp(char(node.getParent.getName),'Trim Definition')
+                                obj.syncTrimDefinitionGeneralNode(node.getParent,false);
+                            elseif any(strcmp(node.getName,{'Linear Model Definition','Mass Properties','Requirement','Simulation'}))
                                 count = node.getChildCount;
                                 for i = 0:(count-1)
                                     currNode = node.getChildAt(i);
                                     currNode.setIcon(obj.JavaImage_unchecked);
                                     currNode.setValue('unselected');
                                 end
-
                             elseif any(strcmp(char(node.getParent.getName),{'Trim Definition','Linear Model Definition','Mass Properties','Requirement','Simulation'}))
                                 count = node.getParent.getChildCount;
                                 for i = 0:(count-1)
@@ -252,6 +253,9 @@ icon_dir = fullfile( this_dir,'..','..','Resources' );
                                 node.setValue('selected');
                                 node.setIcon(obj.JavaImage_checked);
                                 jtree.treeDidChange();
+                                if strcmp(char(parentNode.getName),'Trim Definition') && strcmp(node.getName,'General')
+                                    obj.syncTrimDefinitionGeneralNode(parentNode,true);
+                                end
                             elseif any(strcmp(char(node.getParent.getName),{'Trim Definition','Linear Model Definition','Mass Properties','Requirement','Simulation'}))
                                 count = node.getParent.getChildCount;
                                 for i = 0:(count-1)

--- a/+UserInterface/+StabilityControl/@StabTree/nodeSelection_CB.m
+++ b/+UserInterface/+StabilityControl/@StabTree/nodeSelection_CB.m
@@ -12,7 +12,9 @@ function nodeSelection_CB( obj , node )
                 if strcmp(node.getName,'Trim Definition')
                     obj.syncTrimDefinitionGeneralNode(node,false);
                 end
-                if any(strcmp(node.getName,{'Linear Model Definition','Mass Properties','Requirement'}))
+                if strcmp(node.getName,'General') && strcmp(char(node.getParent.getName),'Trim Definition')
+                    obj.syncTrimDefinitionGeneralNode(node.getParent,false);
+                elseif any(strcmp(node.getName,{'Linear Model Definition','Mass Properties','Requirement'}))
                     count = node.getChildCount;
                     for i = 0:(count-1)
                         currNode = node.getChildAt(i);
@@ -55,12 +57,15 @@ function nodeSelection_CB( obj , node )
                     count = parentNode.getChildCount;
                     for i = 0:(count-1)
                         currNode = parentNode.getChildAt(i);
-                        currNode.setIcon(obj.JavaImage_unchecked); 
+                        currNode.setIcon(obj.JavaImage_unchecked);
                         currNode.setValue('unselected');
                     end
                     node.setValue('selected');
                     node.setIcon(obj.JavaImage_checked);
                     jtree.treeDidChange();
+                    if strcmp(char(parentNode.getName),'Trim Definition') && strcmp(node.getName,'General')
+                        obj.syncTrimDefinitionGeneralNode(parentNode,true);
+                    end
                 elseif any(strcmp(char(node.getParent.getName),{'Trim Definition','Linear Model Definition','Mass Properties','Requirement'}))
                     count = node.getParent.getChildCount;
                     for i = 0:(count-1)


### PR DESCRIPTION
## Summary
- ensure the Trim Definition parent node mirrors selection state changes requested through syncTrimDefinitionGeneralNode
- update mouse and keyboard tree handlers to call the sync helper when the General child is toggled so both nodes stay aligned

## Testing
- not run (UI logic change)


------
https://chatgpt.com/codex/tasks/task_e_68cb31472140832f9c1411f80607fd54