### PR TITLE
Remove checkbox from Trim Definition tree node

### DIFF
--- a/+UserInterface/+StabilityControl/@StabTree/StabTree.m
+++ b/+UserInterface/+StabilityControl/@StabTree/StabTree.m
@@ -1915,12 +1915,8 @@ classdef StabTree < UserInterface.tree
                     parentNode.getChildCount());
                 node.UserData = newObj(index);
 
-                % Mark the parent trim definition group as selected
-                parentNode.setIcon(obj.JavaImage_checked);
-                parentNode.setUserObject('JavaImage_checked');
-                parentNode.setValue('selected');
                 % Insert Model Name
-                
+
 %                 newMdlName = getModelCompiledStateName(newObj(index).SimulinkModelName);
                 newMdlName = newObj(index).SimulinkModelName;
                 
@@ -1946,21 +1942,6 @@ classdef StabTree < UserInterface.tree
             generalNode = [];
             childCount = trimNode.getChildCount();
             stateChanged = false;
-
-            % Ensure the parent node reflects the requested state
-            parentValue = char(trimNode.getValue);
-            parentIsSelected = strcmp(parentValue, 'selected');
-            parentIsUnselected = strcmp(parentValue, 'unselected');
-
-            if isSelected && ~parentIsSelected
-                trimNode.setValue('selected');
-                trimNode.setIcon(obj.JavaImage_checked);
-                stateChanged = true;
-            elseif ~isSelected && ~parentIsUnselected
-                trimNode.setValue('unselected');
-                trimNode.setIcon(obj.JavaImage_unchecked);
-                stateChanged = true;
-            end
 
             for idx = 0:(childCount-1)
                 childNode = trimNode.getChildAt(idx);

--- a/+UserInterface/+StabilityControl/@StabTree/mousePressedInTree_CB.m
+++ b/+UserInterface/+StabilityControl/@StabTree/mousePressedInTree_CB.m
@@ -210,7 +210,7 @@ icon_dir = fullfile( this_dir,'..','..','Resources' );
                                     currNode.setIcon(obj.JavaImage_unchecked);
                                     currNode.setValue('unselected');
                                 end
-                            elseif any(strcmp(char(node.getParent.getName),{'Trim Definition','Linear Model Definition','Mass Properties','Requirement','Simulation'}))
+                            elseif any(strcmp(char(node.getParent.getName),{'Linear Model Definition','Mass Properties','Requirement','Simulation'}))
                                 count = node.getParent.getChildCount;
                                 for i = 0:(count-1)
                                     currNode = node.getParent.getChildAt(i);
@@ -256,7 +256,7 @@ icon_dir = fullfile( this_dir,'..','..','Resources' );
                                 if strcmp(char(parentNode.getName),'Trim Definition') && strcmp(node.getName,'General')
                                     obj.syncTrimDefinitionGeneralNode(parentNode,true);
                                 end
-                            elseif any(strcmp(char(node.getParent.getName),{'Trim Definition','Linear Model Definition','Mass Properties','Requirement','Simulation'}))
+                            elseif any(strcmp(char(node.getParent.getName),{'Linear Model Definition','Mass Properties','Requirement','Simulation'}))
                                 count = node.getParent.getChildCount;
                                 for i = 0:(count-1)
                                     currNode = node.getParent.getChildAt(i);

--- a/+UserInterface/+StabilityControl/@StabTree/nodeSelection_CB.m
+++ b/+UserInterface/+StabilityControl/@StabTree/nodeSelection_CB.m
@@ -22,7 +22,7 @@ function nodeSelection_CB( obj , node )
                         currNode.setValue('unselected');
                     end
 
-                elseif any(strcmp(char(node.getParent.getName),{'Trim Definition','Linear Model Definition','Mass Properties','Requirement'}))
+                elseif any(strcmp(char(node.getParent.getName),{'Linear Model Definition','Mass Properties','Requirement'}))
                     count = node.getParent.getChildCount;
                     for i = 0:(count-1)
                         currNode = node.getParent.getChildAt(i);
@@ -66,7 +66,7 @@ function nodeSelection_CB( obj , node )
                     if strcmp(char(parentNode.getName),'Trim Definition') && strcmp(node.getName,'General')
                         obj.syncTrimDefinitionGeneralNode(parentNode,true);
                     end
-                elseif any(strcmp(char(node.getParent.getName),{'Trim Definition','Linear Model Definition','Mass Properties','Requirement'}))
+                elseif any(strcmp(char(node.getParent.getName),{'Linear Model Definition','Mass Properties','Requirement'}))
                     count = node.getParent.getChildCount;
                     for i = 0:(count-1)
                         currNode = node.getParent.getChildAt(i);


### PR DESCRIPTION
## Summary
- stop marking the Trim Definition group node as a checkbox so it renders like a default tree entry
- adjust trim synchronization logic so the General child stays in sync without toggling the parent node
- update tree click handlers to skip checkbox icon state changes for the Trim Definition group while keeping callbacks intact

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68cc2ee71db8832fa2105d02f29504ad