### PR TITLE
Use UIFigure dialogs for alerts and confirmations

### DIFF
--- a/+UserInterface/+StabilityControl/@Main/Main.m
+++ b/+UserInterface/+StabilityControl/@Main/Main.m
@@ -1254,7 +1254,7 @@ classdef Main < UserInterface.Level1Container %matlab.mixin.Copyable
                 operCondColl = obj.OperCondCollObj(obj.AnalysisTabSelIndex);   
             end
         
-            expOpt = UserInterface.ExportOptions();
+            expOpt = UserInterface.ExportOptions(obj.Figure);
             uiwait(expOpt.Figure);
         
             if expOpt.Range == 0
@@ -1334,9 +1334,10 @@ classdef Main < UserInterface.Level1Container %matlab.mixin.Copyable
             %   Implements new, template, and append report generation
             %   similar to the ControlDesign tool.
 
-            rptType = questdlg('Select report type', 'Export Report', ...
-                'New', 'Template', 'Append', 'New');
-            if isempty(rptType); return; end
+            rptOptions = {'New','Template','Append','Cancel'};
+            rptType = uiconfirm(obj.Figure, 'Select report type', 'Export Report', ...
+                'Options', rptOptions, 'DefaultOption', 'New', 'CancelOption', 'Cancel');
+            if strcmp(rptType, 'Cancel'); return; end
 
             switch rptType
                 case 'Append'
@@ -1873,9 +1874,10 @@ classdef Main < UserInterface.Level1Container %matlab.mixin.Copyable
             %GENERATEREPORTOPENSOURCE Export a report and save as PDF.
             %   Mirrors generateReportLegacy but always writes a PDF file.
 
-            rptType = questdlg('Select report type', 'Export Report', ...
-                'New', 'Template', 'Append', 'New');
-            if isempty(rptType); return; end
+            rptOptions = {'New','Template','Append','Cancel'};
+            rptType = uiconfirm(obj.Figure, 'Select report type', 'Export Report', ...
+                'Options', rptOptions, 'DefaultOption', 'New', 'CancelOption', 'Cancel');
+            if strcmp(rptType, 'Cancel'); return; end
 
             switch rptType
                 case 'Append'
@@ -2459,9 +2461,10 @@ classdef Main < UserInterface.Level1Container %matlab.mixin.Copyable
             if ~isequal(filename,0) 
                 
                 % Ensure user want to continue
-                choice = questdlg('The current project will close. Would you like to continue?', ...
-                    'Close Project?', ...
-                    'Yes','No','No');
+                choice = uiconfirm(obj.Figure, ...
+                    'The current project will close. Would you like to continue?', ...
+                    'Close Project?', 'Options', {'Yes','No'}, ...
+                    'DefaultOption', 'No', 'CancelOption', 'No');
                 % Handle response
                 switch choice
                     case 'Yes'
@@ -2988,9 +2991,11 @@ classdef Main < UserInterface.Level1Container %matlab.mixin.Copyable
                 %--------------------------------------------------------------
                 notify(obj,'ShowLogMessageMain',UserInterface.LogMessageEventData('Saving Trims...','info'));
                 %--------------------------------------------------------------
-                choice = questdlg('An output file is not selected.  How would you like to proceeed?', ...simState
-                    'Saving...', ...
-                    'Create a new output file','Open and existing output file','Do not save','Create a new output file');
+                choice = uiconfirm(obj.Figure, ...
+                    'An output file is not selected.  How would you like to proceeed?', ...
+                    'Saving...', 'Options', {'Create a new output file', ...
+                    'Open and existing output file', 'Do not save', 'Cancel'}, ...
+                    'DefaultOption', 'Create a new output file', 'CancelOption', 'Cancel');
 
                  % Handle response
                 switch choice
@@ -3005,9 +3010,10 @@ classdef Main < UserInterface.Level1Container %matlab.mixin.Copyable
                             fileStruct = load(fileName);
                             fnames = fieldnames(fileStruct);
 
-                            choiceAppend = questdlg('Would you like to append to the existing data?', ...
-                                'Saving...', ...
-                                'Yes','No','Yes');
+                            choiceAppend = uiconfirm(obj.Figure, ...
+                                'Would you like to append to the existing data?', ...
+                                'Saving...', 'Options', {'Yes','No','Cancel'}, ...
+                                'DefaultOption', 'Yes', 'CancelOption', 'Cancel');
                             switch choiceAppend
                                 case 'Yes'
                                     obj.AppendData = true;
@@ -3026,15 +3032,18 @@ classdef Main < UserInterface.Level1Container %matlab.mixin.Copyable
 
                     case 'Do not save'
                         % Do nothing
+                    otherwise
+                        return;
                 end
 
             elseif length(selOutputFile) == 1
                 selOutputFile = selOutputFile{:};
                 fileStruct = load(selOutputFile);
                 fnames = fieldnames(fileStruct);
-                choiceAppend = questdlg('Would you like to append to the existing data?', ...
-                                'Saving...', ...
-                                'Yes','No','Yes');
+                choiceAppend = uiconfirm(obj.Figure, ...
+                    'Would you like to append to the existing data?', ...
+                    'Saving...', 'Options', {'Yes','No','Cancel'}, ...
+                    'DefaultOption', 'Yes', 'CancelOption', 'Cancel');
                 switch choiceAppend
                     case 'Yes'
                         obj.AppendData = true;
@@ -3236,7 +3245,7 @@ classdef Main < UserInterface.Level1Container %matlab.mixin.Copyable
                 
                 switch Mexc.identifier
                     case 'MATLAB:run:FileNotFound'
-                        choice = Utilities.questdlgNonModal(['The file ''',constantsFile,''' does NOT exist on the Matlab path. Please add the path and press continue.'], ...
+                        choice = Utilities.questdlgNonModal(obj.Figure, ['The file ''',constantsFile,''' does NOT exist on the Matlab path. Please add the path and press continue.'], ...
                             'Add Path', ...
                             'Continue','Cancel','Continue');
                         % Handle response
@@ -3250,7 +3259,7 @@ classdef Main < UserInterface.Level1Container %matlab.mixin.Copyable
                                 return;
                         end
                     case 'Simulink:Commands:OpenSystemUnknownSystem'
-                        choice = Utilities.questdlgNonModal(['The model ''',nodeName,''' does NOT exist on the Matlab path. Please add the path and press continue.'], ...
+                        choice = Utilities.questdlgNonModal(obj.Figure, ['The model ''',nodeName,''' does NOT exist on the Matlab path. Please add the path and press continue.'], ...
                             'Add Path', ...
                             'Continue','Cancel','Continue');
                         % Handle response

--- a/+UserInterface/+StabilityControl/@OCCStabControl/OCCStabControl.m
+++ b/+UserInterface/+StabilityControl/@OCCStabControl/OCCStabControl.m
@@ -52,6 +52,7 @@ classdef OCCStabControl < lacm.OperatingConditionCollection
         FilterLabelCont matlab.ui.control.Label = matlab.ui.control.Label.empty
        
         RibbonCardPanel
+        DialogParent matlab.ui.Figure = matlab.ui.Figure.empty
     end % Public properties
     
     %% Table View Properties - Object Handles
@@ -91,10 +92,12 @@ classdef OCCStabControl < lacm.OperatingConditionCollection
             switch nargin
                 case 1
                     obj.Parent = parent;
+                    obj.DialogParent = Utilities.getParentFigure(parent);
                     createView(obj);
-                case 2    
+                case 2
+                    obj.DialogParent = Utilities.getParentFigure(parent);
                     createView(obj, parent , false , toolribbonH);
-                case 3         
+                case 3
             end
             
         end % OCCStabControl
@@ -309,15 +312,21 @@ classdef OCCStabControl < lacm.OperatingConditionCollection
     methods 
         
         function createView( obj , parent , loadingWrkspc , toolribbonH )
-            
+
             % Init inputs for project loading
             if nargin > 1
-                obj.Parent = parent;   
+                obj.Parent = parent;
             end
             if nargin < 3
                 loadingWrkspc = false;
             end
-            
+
+            if nargin > 1 && ~isempty(parent)
+                obj.DialogParent = Utilities.getParentFigure(parent);
+            elseif isempty(obj.DialogParent) || ~isvalid(obj.DialogParent)
+                obj.DialogParent = Utilities.getParentFigure(obj.Parent);
+            end
+
             % Create top container
             obj.Container = uicontainer('Parent',obj.Parent,'Units','normal','Position',[0,0,1,1]);
             % Create Tab Group Inside Container
@@ -814,7 +823,7 @@ classdef OCCStabControl < lacm.OperatingConditionCollection
             if all(logArray)
                 x = cell2mat(x_cell);
             else
-                msgbox('X component must be numeric.');
+                uialert(obj.getDialogParent(), 'X component must be numeric.', 'Invalid Data');
                 return;
             end
             xUnits = obj.TableData{obj.SelectedRows(obj.FirstSelectedRow == obj.SelectedRows),3};
@@ -826,7 +835,7 @@ classdef OCCStabControl < lacm.OperatingConditionCollection
             if all(logArray)
                 y = cell2mat(y_cell);
             else
-                msgbox('Y component must be numeric.');
+                uialert(obj.getDialogParent(), 'Y component must be numeric.', 'Invalid Data');
                 return;
             end
             yUnits = obj.TableData{obj.SelectedRows(obj.SecondSelectedRow == obj.SelectedRows),3};
@@ -911,6 +920,16 @@ classdef OCCStabControl < lacm.OperatingConditionCollection
         
     end
     
+    %% Methods - Private helpers
+    methods (Access = private)
+        function fig = getDialogParent(obj)
+            fig = obj.DialogParent;
+            if isempty(fig) || ~isvalid(fig)
+                fig = Utilities.getParentFigure(obj.Parent);
+            end
+        end % getDialogParent
+    end
+
     %% Method - Delete
     methods
         

--- a/+UserInterface/@ExportOptions/ExportOptions - Copy.m
+++ b/+UserInterface/@ExportOptions/ExportOptions - Copy.m
@@ -1,10 +1,11 @@
 classdef ExportOptions < handle
     
     %% Public properties - Object Handles
-    properties (Transient = true)  
+    properties (Transient = true)
         ButtonGroup
         Figure
-        
+        DialogParent matlab.ui.Figure = matlab.ui.Figure.empty
+
         All_Button
         Select_Button
         SelectPages_EB
@@ -59,7 +60,11 @@ classdef ExportOptions < handle
     
     %% Methods - Constructor
     methods      
-        function obj = ExportOptions( )
+        function obj = ExportOptions(parentFigure)
+            if nargin < 1
+                parentFigure = [];
+            end
+            obj.DialogParent = Utilities.getParentFigure(parentFigure);
             createView( obj );
         end % ExportOptions
     end % Constructor
@@ -141,7 +146,21 @@ classdef ExportOptions < handle
             obj.ButtonGroup.Visible = 'on';
         end % createView
     end
-  
+
+    %% Methods - Private
+    methods (Access = private)
+        function fig = getDialogParent(obj)
+            fig = obj.DialogParent;
+            if isempty(fig) || ~isvalid(fig)
+                fig = Utilities.getParentFigure(obj.Figure);
+            end
+            if isempty(fig) || ~isvalid(fig)
+                error('UserInterface:ExportOptions:MissingParentFigure', ...
+                    'A valid UIFigure parent must be supplied when creating ExportOptions.');
+            end
+        end
+    end
+
     %% Methods - Protected Callbacks
     methods (Access = protected)
         function selectionChg( obj , ~ , eventdata )
@@ -159,7 +178,7 @@ classdef ExportOptions < handle
             try
                 obj.Range = getStrRangeAsVector(str);
             catch
-                msgbox('Only numeric characters "," and "-" can be used to define a range')
+                uialert(obj.getDialogParent(), 'Only numeric characters "," and "-" can be used to define a range', 'Invalid Range');
                 update(obj);
             end
         end % selectedPages_CB

--- a/+Utilities/formatDialogMessage.m
+++ b/+Utilities/formatDialogMessage.m
@@ -1,0 +1,23 @@
+function text = formatDialogMessage(message)
+%FORMATDIALOGMESSAGE Convert dialog message input into a character vector.
+%
+%   text = Utilities.formatDialogMessage(message) accepts character arrays,
+%   string scalars, string arrays, or cell arrays of character vectors and
+%   returns a single character vector separated by newline characters. This
+%   helper ensures messages display correctly in UIFigure-based alerts and
+%   confirmation dialogs.
+
+if nargin < 1 || isempty(message)
+    text = '';
+    return;
+end
+
+if iscell(message)
+    message = string(message(:));
+    message = join(message, newline);
+else
+    message = string(message);
+end
+
+text = char(message);
+end

--- a/+Utilities/getParentFigure.m
+++ b/+Utilities/getParentFigure.m
@@ -1,0 +1,67 @@
+function fig = getParentFigure(candidate)
+%GETPARENTFIGURE Return the owning UIFigure for the supplied candidate.
+%
+%   fig = Utilities.getParentFigure(candidate) walks up typical handle and
+%   object hierarchies to locate the matlab.ui.Figure that should own modal
+%   dialogs. When no UIFigure can be determined an empty array is returned.
+
+fig = matlab.ui.Figure.empty;
+
+if nargin < 1 || isempty(candidate)
+    return;
+end
+
+if iscell(candidate)
+    for k = 1:numel(candidate)
+        fig = Utilities.getParentFigure(candidate{k});
+        if ~isempty(fig)
+            return;
+        end
+    end
+    return;
+end
+
+try
+    if isa(candidate,'matlab.ui.Figure') && isvalid(candidate)
+        fig = candidate;
+        return;
+    end
+catch
+    % ignore objects that do not support isa/isvalid
+end
+
+try
+    if isgraphics(candidate)
+        anc = ancestor(candidate,'figure','toplevel');
+        if ~isempty(anc) && isa(anc,'matlab.ui.Figure') && isvalid(anc)
+            fig = anc;
+            return;
+        end
+    end
+catch
+    % non-graphics inputs may throw, ignore
+end
+
+if isobject(candidate)
+    propNames = {'Figure','UIFigure','ParentFigure','Parent', ...
+        'ParentUIFigure','TreeObj','Tree','Container','ParentContainer'};
+    for k = 1:numel(propNames)
+        if isprop(candidate, propNames{k})
+            try
+                parentCandidate = candidate.(propNames{k});
+            catch
+                parentCandidate = [];
+            end
+            fig = Utilities.getParentFigure(parentCandidate);
+            if ~isempty(fig)
+                return;
+            end
+        end
+    end
+end
+
+currentFig = get(groot,'CurrentFigure');
+if isa(currentFig,'matlab.ui.Figure') && isvalid(currentFig)
+    fig = currentFig;
+end
+end

--- a/+Utilities/questdlgNonModal.m
+++ b/+Utilities/questdlgNonModal.m
@@ -1,0 +1,69 @@
+function choice = questdlgNonModal(parent, message, title, varargin)
+%QUESTDLGNONMODAL UIFigure-aware replacement for legacy questdlg utility.
+%
+%   choice = Utilities.questdlgNonModal(parent, message, title, btn1, btn2, ...)
+%   displays a confirmation dialog owned by the supplied parent UIFigure. The
+%   final argument is treated as the default option when it matches one of the
+%   preceding button labels, mimicking the behaviour of questdlg.
+
+arguments
+    parent
+    message
+    title {mustBeTextScalar(title)}
+end
+arguments (Repeating)
+    varargin
+end
+
+fig = Utilities.getParentFigure(parent);
+if isempty(fig) || ~isvalid(fig)
+    error('Utilities:questdlgNonModal:InvalidParent', ...
+        'Unable to determine a valid UIFigure for dialog display.');
+end
+
+text = Utilities.formatDialogMessage(message);
+
+[options, defaultOption] = iParseOptions(varargin);
+
+args = {'Options', options, 'DefaultOption', defaultOption};
+idxCancel = find(strcmpi(options, 'Cancel'), 1);
+if ~isempty(idxCancel)
+    args = [args, {'CancelOption', options{idxCancel}}]; %#ok<AGROW>
+end
+
+choice = uiconfirm(fig, text, title, args{:});
+end
+
+function [options, defaultOption] = iParseOptions(inputs)
+%IPARSEOPTIONS Derive button options and default selection.
+if isempty(inputs)
+    options = {'OK'};
+    defaultOption = 'OK';
+    return;
+end
+
+raw = cellfun(@string, inputs, 'UniformOutput', false);
+raw = [raw{:}];
+options = cellstr(raw);
+
+if numel(options) >= 2
+    defaultCandidate = options{end};
+    prior = options(1:end-1);
+    if any(strcmp(defaultCandidate, prior))
+        defaultOption = defaultCandidate;
+        options = prior;
+    else
+        defaultOption = options{1};
+    end
+else
+    defaultOption = options{1};
+end
+
+if isempty(options)
+    options = {defaultOption};
+end
+
+if ~any(strcmp(defaultOption, options))
+    options = [options, {defaultOption}]; %#ok<AGROW>
+end
+end

--- a/DYNMain.m
+++ b/DYNMain.m
@@ -130,9 +130,9 @@ classdef DYNMain < handle
             if ~exist(eventdata.Object,'file')
                 % Remove from recent projects
                 prevProjFile = fullfile(obj.ApplicationDataFolder,'previousprojects.flt');
-                Utilities.removeLineInFile( prevProjFile , eventdata.Object );  
+                Utilities.removeLineInFile( prevProjFile , eventdata.Object );
                 launchStartUp( obj );
-                msgbox('This project no longer exists.');
+                uialert(obj.Figure, 'This project no longer exists.', 'Project Missing');
                 return;
             end
             drawnow();
@@ -245,7 +245,7 @@ classdef DYNMain < handle
             verOK = compareVersionNumbers(a, b);
             
             if ~verOK
-                msgbox(['Project Version ',b,' does not match this FLIGHT Dynamics Version ',a,'.'],'Version Info');
+                uialert(obj.Figure, ['Project Version ',b,' does not match this FLIGHT Dynamics Version ',a,'.'], 'Version Info');
             end
                 
             
@@ -348,9 +348,10 @@ classdef DYNMain < handle
             
             releaseAllTrimMdls(obj.ToolObj, [], []);
 
-            choice = questdlg('Would you like to save the current project before closing?', ...
-                'Closing...', ...
-                'Yes','No','Cancel','Cancel');
+            choice = uiconfirm(obj.Figure, ...
+                'Would you like to save the current project before closing?', ...
+                'Closing...', 'Options', {'Yes','No','Cancel'}, ...
+                'DefaultOption', 'Cancel', 'CancelOption', 'Cancel');
             drawnow();pause(0.5);
              % Handle response
             switch choice


### PR DESCRIPTION
## Summary
- capture the parent UIFigure for tree and operating condition controls so alerts and confirmations can target the app window
- replace legacy `questdlg` and `msgbox` calls throughout the Dynamics UI with `uiconfirm`/`uialert`, including the export options dialog
- add Utilities helpers for locating the owning UIFigure, formatting dialog messages, and providing an updated `questdlgNonModal`

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d0612c1c04832fb0c247789b239500